### PR TITLE
added musicdns.org hint

### DIFF
--- a/README
+++ b/README
@@ -30,4 +30,5 @@ http://www.musicip.com/connected_by_musicip.png    or
 http://www.musicip.com/connected_by_musicip.gif
 
 This library is by design compatible with the MusicDNS web service.
-Non-commercial access to the service is available at www.musicdns.org.
+Non-commercial access to the service *was* available at www.musicdns.org.
+(The domain musicdns.org seems to be grabbed by an unrelated third party as of 2016).


### PR DESCRIPTION
Hi  tanob,

musicdns.org seems tp host rather spammy content and does not seem to provide any service with regards to libofa. I reflected this fact in the readme.
Cheers,
tpltnt
